### PR TITLE
Mobile improvements

### DIFF
--- a/mapping/src/mapping.js
+++ b/mapping/src/mapping.js
@@ -143,8 +143,8 @@ function onTouchMove(event) {
         // invoke the pan function
         onMouseMove({
             buttons: 1,
-            movementX: (touch.pageX - touches[0].pageX) * properties.TOUCH_PAN_SENSITIVITY,
-            movementY: (touch.pageY - touches[0].pageY) * properties.TOUCH_PAN_SENSITIVITY
+            movementX: (touch.pageX - touches[0].pageX),
+            movementY: (touch.pageY - touches[0].pageY)
         });
 
         // update to the latest touch point
@@ -169,7 +169,7 @@ function onTouchMove(event) {
 
         // invoke the zoom function
         onWheel({
-            wheelDelta: (newTouchDistance - touchDistance) * properties.TOUCH_SCROLL_SENSITIVITY
+            wheelDelta: (newTouchDistance - touchDistance)
         });
 
         // update to the latest touch points

--- a/mapping/src/mapping.js
+++ b/mapping/src/mapping.js
@@ -66,7 +66,7 @@ function main() {
     // create event listeners for touchscreen support
     addEventListener("touchstart", onTouchStart);
     addEventListener("touchend", onTouchEnd);
-    addEventListener("touchcancel", onTouchCancel);
+    addEventListener("touchcancel", onTouchEnd);
     addEventListener("touchmove", onTouchMove);
 
     // draw the scene and update it each frame
@@ -129,19 +129,8 @@ function onTouchStart(event) {
     }
 }
 
-// when a touch gesture ends, remove all touches that ended
-function onTouchEnd(event) {
-    for (let i = 0; i < event.changedTouches.length; i++) {
-        for (let j = 0; j < touches.length; j++) {
-            if (event.changedTouches.item(i).identifier == touches[j].identifier) {
-                touches.splice(j, 1);
-            }
-        }
-    }
-}
-
-// when touch gestures are canceled, clear the list
-function onTouchCancel() {
+// when touch gestures end, clear the list
+function onTouchEnd() {
     touches.splice(0, touches.length);
 }
 
@@ -183,8 +172,13 @@ function onTouchMove(event) {
             wheelDelta: (newTouchDistance - touchDistance) * properties.TOUCH_SCROLL_SENSITIVITY
         });
 
+        // update to the latest touch points
         touches[0] = touch1;
         touches[1] = touch2;
+    }
+    // otherwise something has gone wrong with the tracking, clear all touches
+    else {
+        onTouchEnd();
     }
 }
 

--- a/mapping/src/properties.js
+++ b/mapping/src/properties.js
@@ -1,7 +1,7 @@
 // load the webgl context
 const canvas = document.getElementById("mapcanvas");
 canvas.width = window.innerWidth;
-canvas.height = window.innerHeight - 4;
+canvas.height = window.innerHeight;
 export const gl = canvas.getContext("webgl2");
 
 // compute viewport properties
@@ -12,13 +12,9 @@ const fov = 0.25 * Math.PI;
 export const SCROLL_SENSITIVITY = 0.001;
 export const MIN_ZOOM = -10;
 export const MAX_ZOOM = 10;
-export const BASE_PAN_SENSITIVITY = 0.1 * 2 ** (MIN_ZOOM - MAX_ZOOM);
+export const BASE_PAN_SENSITIVITY = 50.0 / window.innerHeight * 2 ** (MIN_ZOOM - MAX_ZOOM);
 export const MAX_PAN_SENSITIVITY = 2 ** (4.0 - MIN_ZOOM);
 export const PAN_LIMIT = BigInt(Math.round(2.0 * Math.PI / BASE_PAN_SENSITIVITY));
-
-// constants for touchscreen panning and zooming
-export const TOUCH_PAN_SENSITIVITY = aspect;
-export const TOUCH_SCROLL_SENSITIVITY = 2.0;
 
 // the length of the vertical scale/measuring bar in screen units
 export const SCALE_LENGTH = 2.0 * document.getElementById("scalebar").clientHeight / window.innerHeight;

--- a/mapping/src/properties.js
+++ b/mapping/src/properties.js
@@ -4,6 +4,10 @@ canvas.width = window.innerWidth;
 canvas.height = window.innerHeight - 4;
 export const gl = canvas.getContext("webgl2");
 
+// compute viewport properties
+const aspect = gl.canvas.clientWidth / gl.canvas.clientHeight;
+const fov = 0.25 * Math.PI;
+
 // constants for panning and zooming
 export const SCROLL_SENSITIVITY = 0.001;
 export const MIN_ZOOM = -10;
@@ -13,7 +17,7 @@ export const MAX_PAN_SENSITIVITY = 2 ** (4.0 - MIN_ZOOM);
 export const PAN_LIMIT = BigInt(Math.round(2.0 * Math.PI / BASE_PAN_SENSITIVITY));
 
 // constants for touchscreen panning and zooming
-export const TOUCH_PAN_SENSITIVITY = 0.5;
+export const TOUCH_PAN_SENSITIVITY = aspect;
 export const TOUCH_SCROLL_SENSITIVITY = 2.0;
 
 // the length of the vertical scale/measuring bar in screen units
@@ -57,9 +61,8 @@ export const light = {
 };
 
 // the initial camera view
-const fov = 0.25 * Math.PI;
 export const view = {
-    aspect: gl.canvas.clientWidth / gl.canvas.clientHeight,
+    aspect: aspect,
     fov: fov,
     cameraDistance: 1 / Math.tan(0.5 * fov),
     // precise angles are stored as BigInts to avoid loss of precision at very

--- a/mapping/styles.css
+++ b/mapping/styles.css
@@ -2,6 +2,7 @@ body {
     margin: 0;
     padding: 0;
     touch-action: none;
+    overflow: hidden;
 }
 
 #mapcanvas {
@@ -12,7 +13,7 @@ body {
     position: absolute;
     top: 10%;
     right: 10px;
-    width: 2px;
+    width: 0.5%;
     height: 80%;
     border: 2px solid black;
     background-color: white;
@@ -23,6 +24,11 @@ body {
     position: absolute;
     top: 50%;
     right: 0px;
-    font-size: 3vh;
     background-color: white;
+}
+
+@media (max-height: 500px) {
+    #scalevalue {
+        font-size: 2rem;
+    }
 }

--- a/mapping/styles.css
+++ b/mapping/styles.css
@@ -23,5 +23,6 @@ body {
     position: absolute;
     top: 50%;
     right: 0px;
+    font-size: 3vh;
     background-color: white;
 }


### PR DESCRIPTION
This pull request addresses #5, #4, and #3. The size of the scale number increases to double size when the screen height is below a certain value - a more advanced solution to this may be desirable. The panning speeds are now correctly proportional to the screen height. The tracking of screen touch points was improved to prevent accidental panning at the end of a pinch zoom gesture.